### PR TITLE
typescript 변수가 중복으로 선언되지않는것에대한 결과

### DIFF
--- a/practice/src/java_to_ts/operation01.ts
+++ b/practice/src/java_to_ts/operation01.ts
@@ -22,6 +22,7 @@ const mul : number = 10 * 2;
 const div : number = 10 / 5; 
 const remainder : number = 10 % 5;
 
+
 console.log(add);
 console.log(sub);
 console.log(mul);

--- a/practice/src/sameObject1.ts
+++ b/practice/src/sameObject1.ts
@@ -1,7 +1,15 @@
-const foo = {num : 1234};
-const bar = foo;
+class Foo {
+    constructor() {
+        const foo = {num : 1234};
+        const bar = foo;
+        console.log();
+        bar.num = 0;
+        console.log(foo.num);
+    }
 //  현재 이 것은 변수에 객체 하나를 가지고 둘다 가리키고 있는 셈이다 {num: 1234}라는 객체를 각각 foo와 bar 두개의 변수가 접근하고 있기 때문에
 // 밑에서 bar.num 을 바꾸면 객체자체의 num이 바뀌는 것이다.
-console.log(bar.num);
-bar.num = 0;
-console.log(foo.num);
+}
+
+
+
+

--- a/practice/src/sameObject2.ts
+++ b/practice/src/sameObject2.ts
@@ -1,6 +1,8 @@
-const foo1 = {num : 1234};
-const bar1 = { ...foo1 };
+import { Foo } from "./sameObject1"
+
+const foo = {num : 1235};
+const bar1 = { ...foo };
 // 여기서는 foo1을 복사하여 새로운 객체를 생성한다.
-console.log(bar.num);
-bar.num = 0;
+console.log(bar1.num);
+bar1.num = 0;
 console.log(foo.num);

--- a/practice/src/sameObject3.ts
+++ b/practice/src/sameObject3.ts
@@ -1,0 +1,12 @@
+class FooObj {
+    constructor() {
+        const foo = { num: 1234 };
+        const bar = foo;    
+        const baz = { num: 1234 };
+
+        console.log(foo === bar);
+        console.log(foo === baz);
+    }
+}
+
+new FooObj();

--- a/practice/tsconfig.json
+++ b/practice/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es6"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
scope의 이유로써 ts파일자체가 자바처럼 class가 아니기때문에 전역으로 const변수가 선언되기에  const로 변수를 선언하면 재정의 할 수 없게 되고
해당 부분을 지역변수로 쓰려면 export{} 를 써서 
해당 const변수를 지역변수로 국한시켜야 한다.
그리고 이변수를 추후에 전역상황에서 쓰려면 변수앞에 export를 붙여서 import를 할 수 있게 해야한다.